### PR TITLE
Refine audio overlay and lyrics recovery

### DIFF
--- a/content.css
+++ b/content.css
@@ -1,23 +1,22 @@
 /* Styles for JugiTube content script */
 
 #jugitube-placeholder {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
-  min-height: 420px;
+  min-height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
   border-radius: 18px;
   overflow: hidden;
   box-shadow: 0 25px 60px rgba(9, 11, 23, 0.55);
   pointer-events: none;
   z-index: 10;
   transform: translateZ(0);
+  background: radial-gradient(circle at 30% 20%, rgba(22, 48, 112, 0.75), rgba(8, 12, 32, 0.92));
+  isolation: isolate;
 }
 
 [data-anomfin-audio-only='true'] {
@@ -29,12 +28,13 @@
   position: absolute;
   inset: 0;
   z-index: 0;
-  background-image: linear-gradient(135deg, rgba(18, 31, 70, 0.65), rgba(42, 98, 175, 0.85)), var(--jugitube-background, var(--jugitube-logo));
-  background-size: cover, cover;
-  background-position: center, center;
-  filter: blur(2px);
-  transform: scale(1.1);
-  opacity: 0.9;
+  background-image: linear-gradient(135deg, rgba(10, 19, 52, 0.82), rgba(26, 48, 110, 0.65)),
+    var(--jugitube-background, var(--jugitube-logo));
+  background-size: cover;
+  background-position: center;
+  filter: blur(12px);
+  transform: scale(1.2);
+  opacity: 0.55;
 }
 
 #jugitube-placeholder::after {
@@ -42,52 +42,143 @@
   position: absolute;
   inset: 0;
   z-index: 1;
-  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.35), transparent 60%),
-    radial-gradient(circle at 80% 80%, rgba(255, 215, 0, 0.25), transparent 65%),
-    linear-gradient(135deg, rgba(10, 17, 43, 0.55), rgba(18, 35, 74, 0.65));
-  mix-blend-mode: lighten;
-  opacity: 0.7;
+  background: radial-gradient(circle at 12% 18%, rgba(90, 194, 255, 0.35), transparent 58%),
+    radial-gradient(circle at 80% 76%, rgba(255, 196, 0, 0.2), transparent 60%),
+    linear-gradient(145deg, rgba(6, 14, 34, 0.6), rgba(9, 20, 54, 0.85));
+  mix-blend-mode: screen;
+  opacity: 0.9;
 }
 
 .jugitube-overlay {
   width: 100%;
+  height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 60px 30px;
+  padding: clamp(32px, 6vw, 72px);
   position: relative;
   z-index: 2;
+}
+
+.jugitube-backdrop {
+  position: absolute;
+  inset: -12%;
+  overflow: hidden;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.jugitube-backdrop__grid {
+  position: absolute;
+  inset: -25%;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(140px, 1fr));
+  gap: clamp(40px, 8vw, 120px);
+  transform: rotate(-12deg) scale(1.25);
+  opacity: 0.45;
+  animation: jugitube-grid-drift 26s ease-in-out infinite;
+  filter: drop-shadow(0 38px 90px rgba(0, 0, 0, 0.55));
+}
+
+.jugitube-backdrop__logo {
+  width: clamp(140px, 18vw, 240px);
+  height: clamp(140px, 18vw, 240px);
+  background-image: var(--jugitube-logo);
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  opacity: 0.55;
+  animation: jugitube-logo-orbit 18s ease-in-out infinite;
+}
+
+.jugitube-backdrop__logo--2 {
+  animation-delay: -4s;
+  opacity: 0.4;
+}
+
+.jugitube-backdrop__logo--3 {
+  animation-delay: -8s;
+  opacity: 0.5;
+}
+
+.jugitube-backdrop__logo--4 {
+  animation-delay: -12s;
+  opacity: 0.35;
+}
+
+.jugitube-backdrop__logo--5 {
+  animation-delay: -16s;
+  opacity: 0.45;
+}
+
+.jugitube-backdrop__logo--6 {
+  animation-delay: -20s;
+  opacity: 0.38;
+}
+
+.jugitube-backdrop__veil {
+  position: absolute;
+  inset: -20%;
+  background: linear-gradient(120deg, rgba(10, 18, 44, 0.6), rgba(15, 32, 86, 0.4)),
+    radial-gradient(circle at 25% 25%, rgba(114, 171, 255, 0.35), transparent 70%);
+  mix-blend-mode: soft-light;
+  opacity: 0.85;
+  filter: blur(18px);
+}
+
+.jugitube-backdrop__glow {
+  position: absolute;
+  inset: -18%;
+  background: radial-gradient(circle at 32% 20%, rgba(43, 120, 255, 0.6), transparent 60%),
+    radial-gradient(circle at 72% 78%, rgba(255, 176, 0, 0.4), transparent 65%);
+  opacity: 0.65;
+  filter: blur(38px);
 }
 
 .jugitube-audio-only {
   pointer-events: auto;
   text-align: center;
   color: #f5f7ff;
-  padding: 45px 60px;
-  border-radius: 28px;
-  background: rgba(9, 14, 36, 0.65);
-  backdrop-filter: blur(16px);
-  box-shadow: 0 18px 40px rgba(3, 7, 18, 0.65);
+  padding: clamp(28px, 4.5vw, 56px) clamp(32px, 6vw, 72px);
+  border-radius: 32px;
+  background: rgba(9, 14, 36, 0.78);
+  backdrop-filter: blur(24px) saturate(140%);
+  box-shadow: 0 28px 70px rgba(5, 9, 28, 0.7);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 14px;
-  max-width: 680px;
+  gap: clamp(16px, 2.4vw, 26px);
+  max-width: min(560px, 90%);
+  width: min(560px, 100%);
   position: relative;
-  z-index: 1;
+  z-index: 2;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.jugitube-audio-only::before {
+  content: '';
+  position: absolute;
+  inset: 12px;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  opacity: 0.6;
+  pointer-events: none;
 }
 
 .jugitube-brand-badge {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 18px;
-  background: rgba(28, 42, 88, 0.65);
+  background: rgba(22, 34, 74, 0.72);
   border: 1px solid rgba(255, 255, 255, 0.18);
-  padding: 14px 28px;
+  padding: 16px 28px;
   border-radius: 999px;
-  box-shadow: 0 12px 30px rgba(2, 6, 23, 0.55);
+  box-shadow: 0 20px 40px rgba(2, 6, 23, 0.55);
   text-transform: uppercase;
   letter-spacing: 1.6px;
+  flex-wrap: wrap;
+  text-align: left;
 }
 
 .jugitube-logo-img {
@@ -102,6 +193,7 @@
 .jugitube-brand-text {
   display: flex;
   flex-direction: column;
+  gap: 4px;
   align-items: flex-start;
 }
 
@@ -112,96 +204,96 @@
 }
 
 .jugitube-brand-secondary {
-  font-size: 14px;
-  opacity: 0.75;
+  font-size: 13px;
+  opacity: 0.78;
+  letter-spacing: 2px;
 }
 
 .jugitube-title {
-  font-size: 42px;
+  font-size: clamp(28px, 4.6vw, 44px);
   font-weight: 800;
-  letter-spacing: 2px;
+  letter-spacing: 1.8px;
   text-transform: uppercase;
-  margin-top: 8px;
-  text-shadow: 0 15px 35px rgba(0, 0, 0, 0.55);
+  margin-top: 4px;
+  text-shadow: 0 22px 45px rgba(0, 0, 0, 0.6);
+  text-wrap: balance;
 }
 
 .jugitube-subtitle {
-  font-size: 18px;
-  opacity: 0.9;
-  max-width: 540px;
-  line-height: 1.6;
+  font-size: clamp(16px, 2.2vw, 20px);
+  opacity: 0.95;
+  max-width: min(440px, 100%);
+  line-height: 1.7;
+  text-wrap: pretty;
 }
 
 .jugitube-note {
-  font-size: 16px;
-  opacity: 0.85;
+  font-size: clamp(14px, 1.8vw, 16px);
+  opacity: 0.88;
   font-style: italic;
   background: rgba(255, 255, 255, 0.08);
   padding: 12px 28px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  text-wrap: balance;
 }
 
 .jugitube-credit {
-  margin-top: 12px;
-  font-size: 14px;
-  letter-spacing: 1.4px;
+  margin-top: 6px;
+  font-size: 13px;
+  letter-spacing: 1.2px;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.85);
+  color: rgba(255, 255, 255, 0.9);
+  text-wrap: balance;
 }
 
 .jugitube-credit strong {
   color: #ffe082;
 }
 
-.jugitube-floating-logo {
-  position: absolute;
-  width: 220px;
-  height: 220px;
-  background-image: var(--jugitube-logo);
-  background-size: cover;
-  background-position: center;
-  opacity: 0.18;
-  filter: drop-shadow(0 15px 35px rgba(0, 0, 0, 0.45));
-  animation: jugitube-float 12s ease-in-out infinite;
-  z-index: 0;
-}
-
-.jugitube-floating-logo--one {
-  top: 12%;
-  left: 14%;
-}
-
-.jugitube-floating-logo--two {
-  bottom: 10%;
-  right: 12%;
-  animation-delay: 4s;
-}
-
-@keyframes jugitube-float {
-  0% {
-    transform: translate3d(0, 0, 0) rotate(0deg);
-  }
-  50% {
-    transform: translate3d(12px, -18px, 0) rotate(6deg);
-  }
+@keyframes jugitube-grid-drift {
+  0%,
   100% {
-    transform: translate3d(0, 0, 0) rotate(0deg);
+    transform: rotate(-12deg) scale(1.25) translate3d(0, 0, 0);
+  }
+
+  50% {
+    transform: rotate(-10deg) scale(1.35) translate3d(4%, -3%, 0);
+  }
+}
+
+@keyframes jugitube-logo-orbit {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+
+  25% {
+    transform: translate3d(18px, -22px, 0) scale(1.05) rotate(2deg);
+  }
+
+  50% {
+    transform: translate3d(-16px, 18px, 0) scale(0.95) rotate(-2deg);
+  }
+
+  75% {
+    transform: translate3d(12px, 12px, 0) scale(1.08) rotate(1deg);
   }
 }
 
 @media (max-width: 1024px) {
   .jugitube-audio-only {
-    padding: 36px 28px;
+    padding: 32px 28px;
+    max-width: min(520px, 92%);
   }
 
   .jugitube-title {
-    font-size: 32px;
+    font-size: clamp(26px, 5.2vw, 36px);
   }
 
   .jugitube-brand-badge {
-    flex-direction: column;
-    gap: 12px;
+    gap: 14px;
+    padding: 14px 24px;
   }
 
   .jugitube-logo-img {
@@ -212,25 +304,39 @@
 
 @media (max-width: 768px) {
   #jugitube-placeholder {
-    min-height: 320px;
+    border-radius: 16px;
   }
 
   .jugitube-audio-only {
-    padding: 28px 20px;
+    padding: 28px 22px;
+    max-width: 92%;
+  }
+
+  .jugitube-brand-badge {
     gap: 12px;
-  }
-
-  .jugitube-floating-logo {
-    display: none;
-  }
-
-  .jugitube-title {
-    font-size: 26px;
+    padding: 12px 20px;
   }
 
   .jugitube-subtitle,
   .jugitube-note {
     font-size: 14px;
+  }
+}
+
+@media (max-width: 560px) {
+  .jugitube-brand-badge {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .jugitube-logo-img {
+    width: 60px;
+    height: 60px;
+  }
+
+  .jugitube-title {
+    font-size: 26px;
+    letter-spacing: 1.2px;
   }
 }
 
@@ -244,7 +350,7 @@
   position: fixed;
   bottom: 32px;
   right: 24px;
-  width: min(420px, calc(100vw - 48px));
+  width: min(380px, calc(100vw - 48px));
   max-height: calc(100vh - 64px);
   z-index: 2147483646;
   display: flex;
@@ -262,8 +368,8 @@
   pointer-events: auto;
   display: flex;
   flex-direction: column;
-  width: 100%;
-  min-width: 320px;
+  width: min(380px, calc(100vw - 48px));
+  min-width: 300px;
   max-height: inherit;
   border-radius: 28px;
   overflow: hidden;
@@ -342,6 +448,7 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
+  text-wrap: balance;
 }
 
 .anomfin-lyrics__brand-title {
@@ -356,6 +463,7 @@
   letter-spacing: 2.2px;
   text-transform: uppercase;
   opacity: 0.75;
+  line-height: 1.35;
 }
 
 .anomfin-lyrics__btn {
@@ -375,8 +483,8 @@
 
 .anomfin-lyrics__controls {
   display: flex;
-  align-items: center;
-  gap: 12px;
+  align-items: stretch;
+  gap: 10px;
   flex-wrap: wrap;
   justify-content: flex-end;
 }
@@ -437,6 +545,8 @@
   font-weight: 700;
   letter-spacing: 0.4px;
   text-shadow: 0 12px 24px rgba(0, 0, 0, 0.45);
+  text-wrap: balance;
+  line-height: 1.4;
 }
 
 .anomfin-lyrics__artist {
@@ -444,6 +554,8 @@
   letter-spacing: 2px;
   text-transform: uppercase;
   color: rgba(226, 232, 255, 0.85);
+  text-wrap: balance;
+  line-height: 1.35;
 }
 
 .anomfin-lyrics__status {
@@ -570,6 +682,7 @@
   line-height: 1.6;
   letter-spacing: 0.3px;
   color: rgba(236, 240, 255, 0.88);
+  text-wrap: balance;
 }
 
 .anomfin-lyrics__placeholder--loading {
@@ -585,6 +698,58 @@
   border-color: rgba(248, 113, 113, 0.55);
   background: rgba(127, 29, 29, 0.4);
   color: #ffe4e6;
+}
+
+.anomfin-lyrics__captions {
+  margin: 18px 24px 0;
+  padding: 16px 18px;
+  border-radius: 20px;
+  background: rgba(15, 24, 52, 0.72);
+  border: 1px solid rgba(91, 123, 255, 0.24);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  color: rgba(224, 231, 255, 0.92);
+}
+
+.anomfin-lyrics__captions-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+  letter-spacing: 1.6px;
+  text-transform: uppercase;
+  color: rgba(173, 191, 255, 0.9);
+}
+
+.anomfin-lyrics__captions-title {
+  flex: 1;
+}
+
+.anomfin-lyrics__captions-pill {
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: rgba(91, 123, 255, 0.32);
+  color: #ffffff;
+  font-size: 11px;
+  letter-spacing: 1.8px;
+}
+
+.anomfin-lyrics__captions-feed {
+  min-height: 48px;
+  font-size: 15px;
+  line-height: 1.6;
+  text-wrap: pretty;
+  color: rgba(241, 245, 255, 0.95);
+}
+
+.anomfin-lyrics__captions-hint {
+  margin: 0;
+  font-size: 12px;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: rgba(177, 196, 255, 0.7);
 }
 
 @keyframes anomfin-placeholder-pulse {


### PR DESCRIPTION
## Summary
- redesign the audio-only placeholder to cover the whole player and layer animated AnomFIN logos with responsive sizing
- polish the karaoke console with balanced typography, a corrected Piilota toggle, a manual Hae uudelleen retry button, and YouTube caption fallbacks for missing lyrics
- expand lyrics fetching retries in the background script with progressively looser search combinations when manual retry is requested

## Testing
- ⚠️ not run (browser extension UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68f10957175483328124152d4852b1b8