### PR TITLE
feat: add secure YouTube MP3/MP4 download flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,185 @@
-```md
-# Jugitube — Manual test checklist (added features)
+# Jugitube / AnomTube
 
-Manual test checklist (MVP bundle):
-- Window/State:
-  - Start the app; window opens ~1280x800.
-  - Resize to different size and move; close and reopen app — window restores size/position.
-- Responsive:
-  - Shrink window to width <= 900px — sidebar moves below main content; controls remain visible.
-- Hotkeys:
-  - Play/pause with Space.
-  - Seek -5/+5s with ← / →.
-  - Volume up/down with ↑ / ↓.
-  - Press "d" to trigger download UI action.
-  - Press "t" to toggle theme; selection persists.
-  - Press "p" to toggle PiP.
-- Playlists/bookmarks:
-  - Create a playlist, add an item (url/title), add a bookmark with timestamp, click bookmark -> video jumps there.
-- PiP/themes:
-  - Toggle dark/light theme; refresh page — theme persists.
-  - Try Picture-in-Picture; fallback to Electron mini-window if available.
-- Download backend:
-  - Start backend: cd backend && npm install && node server.js
-  - Test via curl:
-    curl -X POST http://localhost:3000/api/download -H "Content-Type: application/json" -d '{"url":"<VIDEO_URL>","format":"mp3","quality":"high","title":"sample"}' --output sample.mp3
+A clean YouTube helper for Chrome Extension / Electron workflows: audio-only focus mode, ad shield controls, lyrics, themes, PiP, playlists, and a local MP3/MP4 download flow for your own or otherwise licensed content.
 
-Notes:
-- Backend requires yt-dlp and ffmpeg on PATH.
-- For production: add auth, persistent job queue, and more strict rate-limiting.
+> **Legal / security boundary:** the download feature is only for user-owned or permitted content. It does not bypass DRM, paywalls, login walls, or platform restrictions.
 
-## Setup & Run
-- Install deps: `npm install`
-- Run backend (optional downloads): `cd backend && npm install && node server.js`
-- Run width utils test: `node --test tests/toolbarWidth.test.js`
+## Features
 
-## Adjustable toolbar width
-- Open the extension options page and use **Toolbar Width** slider (200–360px) to resolve layout widths without editing code.
-- Toggle **Expand Toolbar** to snap to a wider preset; slider keeps the exact width for fine tuning.
+- Clear **⬇️ Lataa** button in the popup.
+- **D** hotkey on YouTube opens the same download menu.
+- Download menu choices:
+  - `MP3` or `MP4`
+  - quality: `low`, `medium`, `high`
+  - `Lataa` and `Peruutus`
+- Current YouTube URL and title are detected automatically from the active content tab.
+- Frontend calls `POST http://localhost:3000/api/download` with `{ url, format, quality, title }`.
+- Browser receives a blob and starts a native file download with `.mp3` or `.mp4` extension.
+- Status states: ready, loading, success, error.
+
+## Install
+
+```bash
+npm install
+cd backend && npm install
+```
+
+## Required system tools
+
+Install both tools and ensure they are available in `PATH`:
+
+```bash
+yt-dlp --version
+ffmpeg -version
+```
+
+Examples:
+
+```bash
+# macOS
+brew install yt-dlp ffmpeg
+
+# Ubuntu / Debian
+sudo apt update
+sudo apt install ffmpeg
+python3 -m pip install --user yt-dlp
+
+# Windows
+winget install yt-dlp.yt-dlp
+winget install Gyan.FFmpeg
+```
+
+## Run backend
+
+```bash
+cd backend
+npm install
+node server.js
+```
+
+Health check:
+
+```bash
+curl http://localhost:3000/api/health
+```
+
+If `yt-dlp` or `ffmpeg` is missing, `/api/health` returns `503` with a clear error.
+
+## Load the Chrome extension
+
+1. Open Chrome: `chrome://extensions`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked**.
+4. Select this repository folder.
+5. Open a YouTube watch page.
+6. Click the extension popup and press **⬇️ Lataa**, or press **D** on the page.
+
+## Verify downloads manually
+
+Use content you own or are licensed to download.
+
+### Curl MP3 test
+
+```bash
+curl -L -X POST http://localhost:3000/api/download \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://www.youtube.com/watch?v=VIDEO_ID","format":"mp3","quality":"medium","title":"sample"}' \
+  --output sample.mp3
+```
+
+Expected: `sample.mp3` exists and opens as MP3 audio.
+
+### Curl MP4 test
+
+```bash
+curl -L -X POST http://localhost:3000/api/download \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://www.youtube.com/watch?v=VIDEO_ID","format":"mp4","quality":"medium","title":"sample"}' \
+  --output sample.mp4
+```
+
+Expected: `sample.mp4` exists and opens as MP4 video.
+
+### Invalid URL block test
+
+```bash
+curl -i -X POST http://localhost:3000/api/download \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://example.com/video","format":"mp3","quality":"medium","title":"blocked"}'
+```
+
+Expected: HTTP `400` with `Only youtube.com and youtu.be URLs are accepted`.
+
+### UI test checklist
+
+- Start backend: `cd backend && npm install && node server.js`.
+- Open a YouTube video page.
+- Press **D**: the AnomTube download menu opens; no blank tab opens.
+- In the popup, click **⬇️ Lataa**: the same menu opens.
+- Select **MP3**, quality `low / medium / high`, click **Lataa**: status moves `Valmis → Ladataan → Onnistui`, browser downloads `.mp3`.
+- Select **MP4**, click **Lataa**: browser downloads `.mp4`.
+- Stop backend and retry: UI shows `Download backend ei ole käynnissä. Käynnistä: cd backend && npm install && node server.js`.
+- Existing audio-only, ad shield, lyrics, PiP, theme, and playlist controls remain available.
+
+## Test commands
+
+```bash
+node --check popup.js
+node --check content.js
+node --check modules/downloadManager.js
+cd backend && npm test
+```
+
+## Backend API
+
+### `GET /api/health`
+
+Returns backend status, dependency status, and queue size.
+
+### `POST /api/download`
+
+Request body:
+
+```json
+{
+  "url": "https://www.youtube.com/watch?v=VIDEO_ID",
+  "format": "mp3",
+  "quality": "medium",
+  "title": "Safe filename title"
+}
+```
+
+Validation:
+
+- `url`: only `youtube.com` and `youtu.be` hosts.
+- `format`: `mp3` or `mp4`.
+- `quality`: `low`, `medium`, or `high`.
+- `title`: sanitized with `sanitize-filename`.
+
+Implementation:
+
+- MP3 uses `yt-dlp --extract-audio --audio-format mp3`.
+- MP4 uses MP4/M4A selectors and `--merge-output-format mp4`.
+- Missing `yt-dlp` or `ffmpeg` returns a structured `503` response.
+- Download jobs run through a small concurrency queue to avoid local resource spikes.
 
 ## Why this design
-- Local-first settings stored via `localStorage` to avoid extra permissions.
-- Slider-driven width normalization clamps values for safety and predictable CSS.
-- Single source-of-truth width helpers reused across UI and content scripts.
-- Minimal UI: one slider + checkbox instead of nested dialogs.
 
-## TODO
-- Mirror toolbar width control inside the popup for quicker access.
-- Add visual preview of toolbar width on the options page.
+- **Local-first:** conversion happens on `localhost`; no third-party backend receives URLs.
+- **Security-first:** strict host/enum validation and sanitized filenames at the API boundary.
+- **DX-first:** health endpoint, curl tests, and explicit missing-tool errors.
+- **Minimal UX:** one button, one hotkey, one modal, no blank tabs.
+- **Compatibility:** existing feature modules are not replaced; download logic is isolated in `modules/downloadManager.js`.
+
+## Troubleshooting
+
+- **Backend not running:** start it with `cd backend && npm install && node server.js`.
+- **Health returns 503:** install `yt-dlp` and `ffmpeg`, then restart backend.
+- **Chrome blocks localhost call:** reload the extension and confirm `manifest.json` includes `http://localhost:3000/*` host permission.
+- **yt-dlp fails:** update it with your package manager and verify the video is your own or licensed content.
+
+## TODO — next iterations
+
+- Add optional job progress streaming from backend to UI.
+- Add a small diagnostics panel in the popup for backend health.
+- Add CI for backend unit tests and extension syntax checks.

--- a/backend/download-core.js
+++ b/backend/download-core.js
@@ -1,0 +1,150 @@
+// Security-first. Creator-ready. Future-proof.
+// Why this design: pure validation/argument builders keep the Express shell small, testable, and safe at the API boundary.
+
+const sanitizeFilename = require('sanitize-filename');
+
+const ALLOWED_FORMATS = new Set(['mp3', 'mp4']);
+const ALLOWED_QUALITIES = new Set(['low', 'medium', 'high']);
+const YOUTUBE_HOSTS = new Set(['youtube.com', 'www.youtube.com', 'm.youtube.com', 'music.youtube.com', 'youtu.be']);
+const DEFAULT_TITLE = 'anomtube-download';
+
+const AUDIO_QUALITY_ARGS = {
+  low: '9',
+  medium: '5',
+  high: '0'
+};
+
+const MP4_FORMAT_SELECTORS = {
+  low: 'bv*[ext=mp4][height<=360]+ba[ext=m4a]/b[ext=mp4][height<=360]/b[height<=360]',
+  medium: 'bv*[ext=mp4][height<=720]+ba[ext=m4a]/b[ext=mp4][height<=720]/b[height<=720]',
+  high: 'bv*[ext=mp4][height<=1080]+ba[ext=m4a]/b[ext=mp4][height<=1080]/b[height<=1080]/best'
+};
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function validateYouTubeUrl(rawUrl) {
+  const url = normalizeString(rawUrl);
+  if (!url) {
+    return { ok: false, error: 'url is required' };
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch (_error) {
+    return { ok: false, error: 'url must be a valid URL' };
+  }
+
+  if (!['https:', 'http:'].includes(parsed.protocol)) {
+    return { ok: false, error: 'url protocol must be http or https' };
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  const isYouTubeHost = YOUTUBE_HOSTS.has(hostname) || hostname.endsWith('.youtube.com');
+  if (!isYouTubeHost) {
+    return { ok: false, error: 'Only youtube.com and youtu.be URLs are accepted' };
+  }
+
+  return { ok: true, value: parsed.toString() };
+}
+
+function validateEnum(value, allowedValues, fieldName) {
+  const normalized = normalizeString(value).toLowerCase();
+  if (!allowedValues.has(normalized)) {
+    return { ok: false, error: `${fieldName} must be one of: ${Array.from(allowedValues).join(', ')}` };
+  }
+  return { ok: true, value: normalized };
+}
+
+function buildSafeFilenameBase(title) {
+  const normalized = normalizeString(title)
+    .replace(/\s+-\s+YouTube$/i, '')
+    .replace(/\s+/g, ' ')
+    .slice(0, 140);
+
+  const safe = sanitizeFilename(normalized || DEFAULT_TITLE)
+    .replace(/\s+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^\.+/, '')
+    .trim();
+
+  return safe || DEFAULT_TITLE;
+}
+
+function validateDownloadRequest(body = {}) {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return { ok: false, status: 400, error: 'Request body must be a JSON object' };
+  }
+
+  const urlResult = validateYouTubeUrl(body.url);
+  if (!urlResult.ok) {
+    return { ok: false, status: 400, error: urlResult.error };
+  }
+
+  const formatResult = validateEnum(body.format, ALLOWED_FORMATS, 'format');
+  if (!formatResult.ok) {
+    return { ok: false, status: 400, error: formatResult.error };
+  }
+
+  const qualityResult = validateEnum(body.quality, ALLOWED_QUALITIES, 'quality');
+  if (!qualityResult.ok) {
+    return { ok: false, status: 400, error: qualityResult.error };
+  }
+
+  const filenameBase = buildSafeFilenameBase(body.title);
+
+  return {
+    ok: true,
+    value: {
+      url: urlResult.value,
+      format: formatResult.value,
+      quality: qualityResult.value,
+      title: normalizeString(body.title),
+      filenameBase,
+      filename: `${filenameBase}.${formatResult.value}`
+    }
+  };
+}
+
+function buildYtDlpArgs({ url, format, quality }, outputTemplate) {
+  const commonArgs = [
+    '--no-playlist',
+    '--restrict-filenames',
+    '--no-mtime',
+    '--newline',
+    '-o',
+    outputTemplate
+  ];
+
+  if (format === 'mp3') {
+    return [
+      ...commonArgs,
+      '--extract-audio',
+      '--audio-format',
+      'mp3',
+      '--audio-quality',
+      AUDIO_QUALITY_ARGS[quality],
+      url
+    ];
+  }
+
+  return [
+    ...commonArgs,
+    '-f',
+    MP4_FORMAT_SELECTORS[quality],
+    '--merge-output-format',
+    'mp4',
+    url
+  ];
+}
+
+module.exports = {
+  ALLOWED_FORMATS,
+  ALLOWED_QUALITIES,
+  buildSafeFilenameBase,
+  buildYtDlpArgs,
+  validateDownloadRequest,
+  validateYouTubeUrl
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "echo \"Download test: curl -X POST http://localhost:3000/api/download -H 'Content-Type: application/json' -d '{\\\"url\\\": \\\"https://www.youtube.com/watch?v=dQw4w9WgXcQ\\\", \\\"format\\\": \\\"mp3\\\", \\\"quality\\\": \\\"medium\\\"}'\""
+    "test": "node --test tests/*.test.js"
   },
   "keywords": [
     "youtube",
@@ -28,6 +28,6 @@
     "nodemon": "^3.0.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,107 +1,207 @@
-// Lightweight Express backend for /api/download
-// Requires: npm i express express-rate-limit cors sanitize-filename
-// System: yt-dlp and ffmpeg should be installed; fallback returns 501 if missing.
+// Less noise. More signal. AnomFIN.
+// Why this design: validate before IO, isolate yt-dlp jobs, and return files only after successful conversion.
 
-const express = require('express');
-const rateLimit = require('express-rate-limit');
 const cors = require('cors');
-const sanitize = require('sanitize-filename');
+const express = require('express');
+const fs = require('fs/promises');
+const os = require('os');
+const path = require('path');
+const rateLimit = require('express-rate-limit');
 const { spawn } = require('child_process');
+const { spawnSync } = require('child_process');
+const {
+  buildSafeFilenameBase,
+  buildYtDlpArgs,
+  validateDownloadRequest
+} = require('./download-core');
 
-const MAX_CONCURRENT = 3;
-let current = 0;
-const QUEUE = [];
+const PORT = Number.parseInt(process.env.PORT || '3000', 10);
+const MAX_CONCURRENT_DOWNLOADS = Number.parseInt(process.env.MAX_CONCURRENT_DOWNLOADS || '2', 10);
+const DOWNLOAD_TIMEOUT_MS = Number.parseInt(process.env.DOWNLOAD_TIMEOUT_MS || String(10 * 60 * 1000), 10);
+const BODY_LIMIT = '64kb';
 
-function enqueue(task) {
-  QUEUE.push(task);
-  processQueue();
+let activeDownloads = 0;
+const downloadQueue = [];
+
+function log(level, message, meta = {}) {
+  console[level === 'error' ? 'error' : level === 'warn' ? 'warn' : 'log'](
+    JSON.stringify({ level, message, time: new Date().toISOString(), ...meta })
+  );
 }
 
-function processQueue() {
-  if (current >= MAX_CONCURRENT) return;
-  const task = QUEUE.shift();
-  if (!task) return;
-  current++;
-  task(() => {
-    current--;
-    processQueue();
+function enqueueDownload(job) {
+  downloadQueue.push(job);
+  processDownloadQueue();
+}
+
+function processDownloadQueue() {
+  if (activeDownloads >= MAX_CONCURRENT_DOWNLOADS) return;
+  const job = downloadQueue.shift();
+  if (!job) return;
+
+  activeDownloads += 1;
+  job(() => {
+    activeDownloads -= 1;
+    processDownloadQueue();
   });
 }
 
-const app = express();
-app.use(cors());
-app.use(express.json({ limit: '1mb' }));
-
-const limiter = rateLimit({
-  windowMs: 60 * 1000,
-  max: 10, // 10 requests per minute per IP
-});
-app.use('/api/download', limiter);
-
-function checkCommand(cmd, args = ['--version']) {
-  try {
-    const p = spawn(cmd, args);
-    p.on('error', () => {});
-    return true;
-  } catch (e) {
-    return false;
-  }
+function commandExists(command) {
+  const result = spawnSync(command, ['--version'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'ignore', 'ignore']
+  });
+  return !result.error && result.status === 0;
 }
 
-app.post('/api/download', (req, res) => {
-  const { url, format = 'mp4', quality = 'high', title = 'jugitube' } = req.body || {};
-  if (!url) return res.status(400).json({ error: 'Missing url' });
+function assertRuntimeDependencies() {
+  const missing = ['yt-dlp', 'ffmpeg'].filter((command) => !commandExists(command));
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      error: `Missing required command(s) in PATH: ${missing.join(', ')}. Install yt-dlp and ffmpeg, then restart the backend.`
+    };
+  }
+  return { ok: true };
+}
 
-  const filenameBase = sanitize(title).replace(/\s+/g, '_') || 'file';
-  const ext = format === 'mp3' ? 'mp3' : 'mp4';
-  res.setHeader('Content-Type', 'application/octet-stream');
-  res.setHeader('Content-Disposition', `attachment; filename="${filenameBase}.${ext}"`);
+async function findDownloadedFile(directory, expectedExtension) {
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  const files = entries
+    .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith(`.${expectedExtension}`))
+    .map((entry) => path.join(directory, entry.name));
 
-  const job = (done) => {
-    // Choose args for yt-dlp
-    let args = ['--no-playlist', '-o', '-', url];
-    if (format === 'mp3') {
-      args = ['--no-playlist', '--extract-audio', '--audio-format', 'mp3', '--audio-quality', quality === 'high' ? '0' : quality === 'medium' ? '5' : '9', '-o', '-', url];
-    } else {
-      let selector = 'best';
-      if (quality === 'low') selector = 'bestvideo[height<=360]+bestaudio/best';
-      else if (quality === 'medium') selector = 'bestvideo[height<=720]+bestaudio/best';
-      else selector = 'bestvideo[height<=1080]+bestaudio/best';
-      args = ['--no-playlist', '-f', selector, '-o', '-', url];
-    }
+  if (files.length === 0) {
+    throw new Error(`yt-dlp did not produce a .${expectedExtension} file`);
+  }
 
-    // Spawn yt-dlp
-    const child = spawn('yt-dlp', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+  return files[0];
+}
 
-    const killTimer = setTimeout(() => {
-      try { child.kill('SIGKILL'); } catch (e) {}
-    }, 5 * 60 * 1000); // 5 minutes
+function runYtDlp(args, { requestId }) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('yt-dlp', args, {
+      stdio: ['ignore', 'ignore', 'pipe'],
+      windowsHide: true
+    });
 
-    child.stdout.pipe(res, { end: true });
+    let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`yt-dlp timed out after ${DOWNLOAD_TIMEOUT_MS}ms`));
+    }, DOWNLOAD_TIMEOUT_MS);
 
-    child.stderr.on('data', (d) => {
-      console.error('yt-dlp:', d.toString());
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+      if (stderr.length > 6000) stderr = stderr.slice(-6000);
+    });
+
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
     });
 
     child.on('close', (code) => {
-      clearTimeout(killTimer);
+      clearTimeout(timer);
       if (code !== 0) {
-        if (!res.headersSent) res.status(500).json({ error: 'yt-dlp failed', code });
+        reject(new Error(`yt-dlp exited with code ${code}: ${stderr.trim() || 'no stderr'}`));
+        return;
       }
-      try { res.end(); } catch (e) {}
-      done();
+      log('info', 'yt-dlp completed', { requestId });
+      resolve();
     });
+  });
+}
 
-    child.on('error', (err) => {
-      clearTimeout(killTimer);
-      console.error('yt-dlp spawn error', err);
-      if (!res.headersSent) res.status(500).json({ error: 'spawn failed' });
-      done();
+async function sendFileAndCleanup(res, filePath, filename, tempDir) {
+  await new Promise((resolve, reject) => {
+    res.download(filePath, filename, (error) => {
+      if (error) reject(error);
+      else resolve();
     });
-  };
+  }).finally(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+}
 
-  enqueue(job);
-});
+async function handleDownload(req, res) {
+  const validation = validateDownloadRequest(req.body);
+  if (!validation.ok) {
+    res.status(validation.status).json({ error: validation.error });
+    return;
+  }
 
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => console.log(`Download server listening on ${PORT}`));
+  const dependencyStatus = assertRuntimeDependencies();
+  if (!dependencyStatus.ok) {
+    res.status(503).json({ error: dependencyStatus.error });
+    return;
+  }
+
+  const download = validation.value;
+  const requestId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'anomtube-'));
+  const outputBase = buildSafeFilenameBase(`${download.filenameBase}-${requestId}`);
+  const outputTemplate = path.join(tempDir, `${outputBase}.%(ext)s`);
+  const args = buildYtDlpArgs(download, outputTemplate);
+
+  log('info', 'download started', {
+    requestId,
+    host: new URL(download.url).hostname,
+    format: download.format,
+    quality: download.quality
+  });
+
+  try {
+    await runYtDlp(args, { requestId });
+    const filePath = await findDownloadedFile(tempDir, download.format);
+    res.setHeader('X-AnomTube-Status', 'success');
+    await sendFileAndCleanup(res, filePath, download.filename, tempDir);
+    log('info', 'download delivered', { requestId, filename: download.filename });
+  } catch (error) {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    log('error', 'download failed', { requestId, error: error.message });
+    if (!res.headersSent) {
+      res.status(500).json({ error: 'Download failed. Verify the URL, content permissions, yt-dlp, and ffmpeg.' });
+    }
+  }
+}
+
+function createApp() {
+  const app = express();
+
+  app.use(cors({ origin: true }));
+  app.use(express.json({ limit: BODY_LIMIT }));
+
+  app.get('/api/health', (_req, res) => {
+    const dependencies = assertRuntimeDependencies();
+    res.status(dependencies.ok ? 200 : 503).json({
+      ok: dependencies.ok,
+      service: 'anomtube-download-backend',
+      dependencies: dependencies.ok ? { ytDlp: true, ffmpeg: true } : { error: dependencies.error },
+      queue: { active: activeDownloads, pending: downloadQueue.length }
+    });
+  });
+
+  app.post(
+    '/api/download',
+    rateLimit({ windowMs: 60 * 1000, max: 12, standardHeaders: true, legacyHeaders: false }),
+    (req, res) => enqueueDownload((done) => handleDownload(req, res).finally(done))
+  );
+
+  app.use((error, _req, res, _next) => {
+    log('error', 'unhandled request error', { error: error.message });
+    if (!res.headersSent) {
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  return app;
+}
+
+if (require.main === module) {
+  createApp().listen(PORT, () => {
+    log('info', 'download backend listening', { port: PORT });
+  });
+}
+
+module.exports = { createApp, commandExists, assertRuntimeDependencies };

--- a/backend/tests/download-core.test.js
+++ b/backend/tests/download-core.test.js
@@ -1,0 +1,64 @@
+// From raw data to real impact.
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  buildSafeFilenameBase,
+  buildYtDlpArgs,
+  validateDownloadRequest,
+  validateYouTubeUrl
+} = require('../download-core');
+
+test('validateYouTubeUrl accepts youtube.com and youtu.be', () => {
+  assert.equal(validateYouTubeUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ').ok, true);
+  assert.equal(validateYouTubeUrl('https://youtu.be/dQw4w9WgXcQ').ok, true);
+});
+
+test('validateYouTubeUrl blocks non-YouTube URLs', () => {
+  const result = validateYouTubeUrl('https://example.com/watch?v=dQw4w9WgXcQ');
+  assert.equal(result.ok, false);
+  assert.match(result.error, /youtube\.com|youtu\.be/i);
+});
+
+test('validateDownloadRequest enforces format and quality enums', () => {
+  const badFormat = validateDownloadRequest({
+    url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    format: 'wav',
+    quality: 'high'
+  });
+  assert.equal(badFormat.ok, false);
+  assert.match(badFormat.error, /format/);
+
+  const badQuality = validateDownloadRequest({
+    url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    format: 'mp3',
+    quality: 'ultra'
+  });
+  assert.equal(badQuality.ok, false);
+  assert.match(badQuality.error, /quality/);
+});
+
+test('buildSafeFilenameBase strips unsafe characters and YouTube suffix', () => {
+  assert.equal(buildSafeFilenameBase('AC/DC: Thunder? - YouTube'), 'ACDC_Thunder');
+  assert.equal(buildSafeFilenameBase('..'), 'anomtube-download');
+});
+
+test('buildYtDlpArgs creates mp3 extraction args', () => {
+  const args = buildYtDlpArgs(
+    { url: 'https://youtu.be/dQw4w9WgXcQ', format: 'mp3', quality: 'medium' },
+    '/tmp/%(title)s.%(ext)s'
+  );
+  assert.ok(args.includes('--extract-audio'));
+  assert.ok(args.includes('--audio-format'));
+  assert.ok(args.includes('mp3'));
+});
+
+test('buildYtDlpArgs creates mp4 merge args', () => {
+  const args = buildYtDlpArgs(
+    { url: 'https://youtu.be/dQw4w9WgXcQ', format: 'mp4', quality: 'high' },
+    '/tmp/%(title)s.%(ext)s'
+  );
+  assert.ok(args.includes('--merge-output-format'));
+  assert.ok(args.includes('mp4'));
+  assert.ok(args.includes('-f'));
+});

--- a/content.js
+++ b/content.js
@@ -1,4 +1,5 @@
 // Content script for AnomTube extension
+// Commit to intelligence. Push innovation. Pull results.
 // WeakMap to store stable button IDs
 const _buttonIds = new WeakMap();
 let _nextButtonId = 1;
@@ -97,7 +98,7 @@ class AnomTube {
 
   async init() {
     const [syncState, assets] = await Promise.all([
-      chrome.storage.sync.get(['enabled', 'muteAds', 'skipAds', 'blockAds', 'hideLyrics', 'allowVideo']),
+      chrome.storage.sync.get(['enabled', 'muteAds', 'skipAds', 'blockAds', 'hideLyrics', 'allowVideo', 'autoClickSkipAds', 'allowVideoKeepAdSettings', 'hidePopupCompletely', 'expandToolbar']),
       chrome.storage.local.get(['customBackground', 'customLogo', 'lyricsConsolePosition'])
     ]);
 
@@ -107,6 +108,10 @@ class AnomTube {
     this.adPreferences.blockAds = Boolean(syncState.blockAds);
     this.hideLyrics = Boolean(syncState.hideLyrics);
     this.allowVideo = Boolean(syncState.allowVideo);
+    this.settings.autoClickSkipAds = Boolean(syncState.autoClickSkipAds);
+    this.settings.allowVideoKeepAdSettings = Boolean(syncState.allowVideoKeepAdSettings);
+    this.settings.hidePopupCompletely = Boolean(syncState.hidePopupCompletely);
+    this.settings.expandToolbar = typeof syncState.expandToolbar === 'undefined' ? true : Boolean(syncState.expandToolbar);
     this.customAssets.background = assets.customBackground || null;
     this.customAssets.logo = assets.customLogo || null;
     this.lyricsPosition = assets.lyricsConsolePosition || null;
@@ -117,7 +122,7 @@ class AnomTube {
     await this.downloadManager.init();
 
     // Setup hotkey callbacks
-    this.hotkeyManager.on('toggleDownload', () => this.downloadManager.toggleDownloadUI());
+    this.hotkeyManager.on('toggleDownload', () => this.downloadManager.openDownloadMenu());
     this.hotkeyManager.on('toggleTheme', () => this.themeManager.toggleTheme());
 
     if (this.isEnabled) {
@@ -143,6 +148,10 @@ class AnomTube {
         this.hotkeyManager.togglePiP();
       } else if (request.action === 'toggleDownload') {
         this.downloadManager.toggleDownloadUI();
+      } else if (request.action === 'openDownloadMenu') {
+        this.downloadManager.openDownloadMenu();
+      } else if (request.action === 'startDownload') {
+        this.downloadManager.startDownload(request.options || {});
       } else if (request.action === 'openPlaylistManager') {
         this.openPlaylistManager();
       }
@@ -340,9 +349,11 @@ class AnomTube {
    * Handle open download UI hotkey
    */
   handleOpenDownload() {
-    // This would open a download UI modal or panel
-    console.log('Download UI requested');
-    this.showNotification('Download feature: Press D or use extension popup', 3000);
+    if (this.downloadManager) {
+      this.downloadManager.openDownloadMenu();
+      return;
+    }
+    this.showNotification('Download manager is not available', 3000);
   }
 
   /**
@@ -550,6 +561,26 @@ class AnomTube {
   }
 
   updateSettings(settings = {}) {
+    const adKeys = ['muteAds', 'skipAds', 'blockAds'];
+    const adPreferenceUpdates = {};
+    adKeys.forEach((key) => {
+      if (Object.prototype.hasOwnProperty.call(settings, key)) {
+        adPreferenceUpdates[key] = settings[key];
+      }
+    });
+
+    if (Object.keys(adPreferenceUpdates).length > 0) {
+      this.updateAdPreferences(adPreferenceUpdates);
+    }
+
+    ['autoClickSkipAds', 'allowVideoKeepAdSettings', 'hidePopupCompletely', 'expandToolbar'].forEach((key) => {
+      if (Object.prototype.hasOwnProperty.call(settings, key)) {
+        this.settings[key] = Boolean(settings[key]);
+      }
+    });
+
+    this.applyToolbarExpansion();
+
     if (Object.prototype.hasOwnProperty.call(settings, 'hideLyrics')) {
       const newValue = Boolean(settings.hideLyrics);
       if (this.hideLyrics !== newValue) {

--- a/manifest.json
+++ b/manifest.json
@@ -8,18 +8,23 @@
     "activeTab",
     "storage",
     "scripting",
-    "downloads"
+    "downloads",
+    "tabs"
   ],
   "host_permissions": [
     "*://*.youtube.com/*",
     "*://*.googleapis.com/*",
     "https://lrclib.net/*",
     "https://api.lyrics.ovh/*",
-    "https://some-random-api.ml/*"
+    "https://some-random-api.ml/*",
+    "*://youtu.be/*",
+    "http://localhost:3000/*"
   ],
   "content_scripts": [
     {
-      "matches": ["*://*.youtube.com/*"],
+      "matches": [
+        "*://*.youtube.com/*"
+      ],
       "js": [
         "modules/settings.js",
         "modules/adSkipper.js",
@@ -58,8 +63,14 @@
   },
   "web_accessible_resources": [
     {
-      "resources": ["asd.png", "logo.png", "logo_ANOMFIN_AUTOMATED_AI.png"],
-      "matches": ["*://*.youtube.com/*"]
+      "resources": [
+        "asd.png",
+        "logo.png",
+        "logo_ANOMFIN_AUTOMATED_AI.png"
+      ],
+      "matches": [
+        "*://*.youtube.com/*"
+      ]
     }
   ]
 }

--- a/modules/downloadManager.js
+++ b/modules/downloadManager.js
@@ -1,298 +1,281 @@
-// Download Manager for AnomTube extension
-// Handles downloading YouTube videos/audio with quality options
+// AnomTube: Strip the noise, stream the essence.
+// Why this design: one local modal owns validation, state, and blob download without opening tabs or touching unrelated features.
 
 class DownloadManager {
   constructor() {
     this.isDownloadUIVisible = false;
-    this.downloadOptions = {
-      format: 'mp3', // mp3 or mp4
-      quality: 'medium' // low, medium, high
-    };
+    this.isDownloading = false;
     this.storageKey = 'anomTubeDownloadSettings';
+    this.backendUrl = 'http://localhost:3000/api/download';
+    this.downloadOptions = {
+      format: 'mp3',
+      quality: 'medium'
+    };
   }
 
   async init() {
     const result = await chrome.storage.local.get([this.storageKey]);
-    if (result[this.storageKey]) {
+    if (result[this.storageKey] && typeof result[this.storageKey] === 'object') {
       this.downloadOptions = { ...this.downloadOptions, ...result[this.storageKey] };
     }
   }
 
   async saveSettings() {
-    await chrome.storage.local.set({
-      [this.storageKey]: this.downloadOptions
-    });
+    await chrome.storage.local.set({ [this.storageKey]: this.downloadOptions });
   }
 
   toggleDownloadUI() {
-    this.isDownloadUIVisible = !this.isDownloadUIVisible;
-    
     if (this.isDownloadUIVisible) {
-      this.showDownloadUI();
-    } else {
       this.hideDownloadUI();
+      return;
     }
+    this.showDownloadUI();
+  }
+
+  openDownloadMenu() {
+    this.showDownloadUI();
   }
 
   showDownloadUI() {
-    // Check if UI already exists
-    let downloadPanel = document.getElementById('anomtube-download-panel');
-    
-    if (!downloadPanel) {
-      downloadPanel = this.createDownloadUI();
-      document.body.appendChild(downloadPanel);
-    } else {
-      downloadPanel.style.display = 'block';
+    let panel = document.getElementById('anomtube-download-panel');
+    if (!panel) {
+      panel = this.createDownloadUI();
+      document.body.appendChild(panel);
     }
+
+    panel.style.display = 'block';
+    this.isDownloadUIVisible = true;
+    this.renderSelectionState();
+    this.showStatus('Valmis — valitse formaatti ja laatu.', 'ready');
   }
 
   hideDownloadUI() {
-    const downloadPanel = document.getElementById('anomtube-download-panel');
-    if (downloadPanel) {
-      downloadPanel.style.display = 'none';
-    }
+    const panel = document.getElementById('anomtube-download-panel');
+    if (panel) panel.style.display = 'none';
+    this.isDownloadUIVisible = false;
   }
 
   createDownloadUI() {
     const panel = document.createElement('div');
     panel.id = 'anomtube-download-panel';
+    panel.setAttribute('role', 'dialog');
+    panel.setAttribute('aria-label', 'AnomTube latausvalikko');
     panel.style.cssText = `
       position: fixed;
-      top: 80px;
-      right: 20px;
-      width: 320px;
-      background: linear-gradient(135deg, rgba(10, 14, 26, 0.98) 0%, rgba(18, 24, 43, 0.98) 100%);
-      border: 1px solid rgba(255, 255, 255, 0.15);
-      border-radius: 16px;
+      top: 84px;
+      right: 24px;
+      width: min(360px, calc(100vw - 32px));
       padding: 20px;
-      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
-      z-index: 999998;
-      backdrop-filter: blur(20px);
-      font-family: 'SF Pro Display', 'Inter', 'Segoe UI', sans-serif;
+      z-index: 2147483646;
       color: #f8faff;
+      font-family: Inter, "SF Pro Display", "Segoe UI", system-ui, sans-serif;
+      background: radial-gradient(circle at top left, rgba(108,168,255,.24), transparent 42%), linear-gradient(145deg, rgba(5,10,22,.96), rgba(12,18,36,.97));
+      border: 1px solid rgba(180, 210, 255, .20);
+      border-radius: 22px;
+      box-shadow: 0 24px 90px rgba(0,0,0,.55), inset 0 1px 0 rgba(255,255,255,.08);
+      backdrop-filter: blur(22px) saturate(150%);
     `;
 
     panel.innerHTML = `
-      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
-        <h3 style="margin: 0; font-size: 16px; letter-spacing: 1.5px; text-transform: uppercase;">Download Video</h3>
-        <button id="anomtube-download-close" style="
-          background: transparent;
-          border: none;
-          color: #f8faff;
-          font-size: 20px;
-          cursor: pointer;
-          padding: 0;
-          width: 24px;
-          height: 24px;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-        ">×</button>
-      </div>
-
-      <div style="margin-bottom: 16px;">
-        <label style="display: block; margin-bottom: 8px; font-size: 12px; letter-spacing: 1.2px; text-transform: uppercase; opacity: 0.8;">Format</label>
-        <div style="display: flex; gap: 10px;">
-          <button class="format-btn" data-format="mp3" style="
-            flex: 1;
-            padding: 12px;
-            background: ${this.downloadOptions.format === 'mp3' ? 'rgba(108, 168, 255, 0.3)' : 'rgba(255, 255, 255, 0.05)'};
-            border: 1px solid ${this.downloadOptions.format === 'mp3' ? 'rgba(108, 168, 255, 0.6)' : 'rgba(255, 255, 255, 0.15)'};
-            border-radius: 10px;
-            color: #f8faff;
-            cursor: pointer;
-            font-size: 14px;
-            letter-spacing: 1.5px;
-            transition: all 0.2s;
-          ">🎵 MP3</button>
-          <button class="format-btn" data-format="mp4" style="
-            flex: 1;
-            padding: 12px;
-            background: ${this.downloadOptions.format === 'mp4' ? 'rgba(108, 168, 255, 0.3)' : 'rgba(255, 255, 255, 0.05)'};
-            border: 1px solid ${this.downloadOptions.format === 'mp4' ? 'rgba(108, 168, 255, 0.6)' : 'rgba(255, 255, 255, 0.15)'};
-            border-radius: 10px;
-            color: #f8faff;
-            cursor: pointer;
-            font-size: 14px;
-            letter-spacing: 1.5px;
-            transition: all 0.2s;
-          ">🎬 MP4</button>
+      <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:14px;margin-bottom:18px;">
+        <div>
+          <div style="font-size:11px;letter-spacing:2.4px;text-transform:uppercase;color:#82b7ff;margin-bottom:6px;">AnomTube Download</div>
+          <h3 style="margin:0;font-size:20px;line-height:1.1;letter-spacing:.4px;">⬇️ Lataa nykyinen video</h3>
         </div>
+        <button id="anomtube-download-close" type="button" aria-label="Peruuta" style="width:34px;height:34px;border-radius:12px;border:1px solid rgba(255,255,255,.14);background:rgba(255,255,255,.06);color:#fff;cursor:pointer;font-size:20px;">×</button>
       </div>
 
-      <div style="margin-bottom: 20px;">
-        <label style="display: block; margin-bottom: 8px; font-size: 12px; letter-spacing: 1.2px; text-transform: uppercase; opacity: 0.8;">Quality</label>
-        <select id="anomtube-quality-select" style="
-          width: 100%;
-          padding: 12px;
-          background: rgba(255, 255, 255, 0.05);
-          border: 1px solid rgba(255, 255, 255, 0.15);
-          border-radius: 10px;
-          color: #f8faff;
-          font-size: 14px;
-          cursor: pointer;
-        ">
-          <option value="low" ${this.downloadOptions.quality === 'low' ? 'selected' : ''}>Low (Faster)</option>
-          <option value="medium" ${this.downloadOptions.quality === 'medium' ? 'selected' : ''}>Medium (Balanced)</option>
-          <option value="high" ${this.downloadOptions.quality === 'high' ? 'selected' : ''}>High (Best Quality)</option>
-        </select>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:16px;">
+        <button class="anomtube-format-btn" data-format="mp3" type="button">MP3</button>
+        <button class="anomtube-format-btn" data-format="mp4" type="button">MP4</button>
       </div>
 
-      <button id="anomtube-download-btn" style="
-        width: 100%;
-        padding: 14px;
-        background: linear-gradient(135deg, rgba(120, 174, 255, 0.4), rgba(176, 120, 255, 0.4));
-        border: 1px solid rgba(255, 255, 255, 0.3);
-        border-radius: 10px;
-        color: #f8faff;
-        font-size: 14px;
-        letter-spacing: 1.8px;
-        text-transform: uppercase;
-        cursor: pointer;
-        font-weight: 600;
-        transition: all 0.2s;
-      ">⬇ Download</button>
+      <label for="anomtube-quality-select" style="display:block;font-size:11px;letter-spacing:1.8px;text-transform:uppercase;color:rgba(248,250,255,.72);margin-bottom:8px;">Laatu</label>
+      <select id="anomtube-quality-select" style="width:100%;padding:13px 12px;border-radius:14px;border:1px solid rgba(255,255,255,.14);background:#10182d;color:#f8faff;outline:none;margin-bottom:16px;">
+        <option value="low">low — nopea / kevyt</option>
+        <option value="medium">medium — tasapaino</option>
+        <option value="high">high — paras laatu</option>
+      </select>
 
-      <div id="anomtube-download-status" style="
-        margin-top: 12px;
-        padding: 10px;
-        background: rgba(255, 255, 255, 0.05);
-        border-radius: 8px;
-        font-size: 12px;
-        text-align: center;
-        display: none;
-      "></div>
+      <div id="anomtube-download-status" style="display:block;min-height:42px;padding:12px 13px;margin-bottom:14px;border-radius:14px;border:1px solid rgba(255,255,255,.10);background:rgba(255,255,255,.055);font-size:13px;line-height:1.35;color:rgba(248,250,255,.86);"></div>
 
-      <div style="margin-top: 16px; padding-top: 16px; border-top: 1px solid rgba(255, 255, 255, 0.1);">
-        <p style="font-size: 11px; opacity: 0.6; margin: 0; line-height: 1.5;">
-          Note: Download uses browser's native download. For MP3 conversion, you may need additional tools.
-        </p>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;">
+        <button id="anomtube-download-btn" type="button" style="padding:13px 14px;border-radius:14px;border:1px solid rgba(108,168,255,.48);background:linear-gradient(135deg, rgba(108,168,255,.36), rgba(181,108,255,.30));color:#fff;font-weight:800;letter-spacing:1.4px;text-transform:uppercase;cursor:pointer;">Lataa</button>
+        <button id="anomtube-download-cancel" type="button" style="padding:13px 14px;border-radius:14px;border:1px solid rgba(255,255,255,.14);background:rgba(255,255,255,.06);color:#fff;font-weight:700;letter-spacing:1.1px;text-transform:uppercase;cursor:pointer;">Peruutus</button>
       </div>
+
+      <p style="margin:14px 0 0;font-size:11px;line-height:1.45;color:rgba(248,250,255,.52);">Käytä vain omaan tai luvalliseen sisältöön. Ei DRM:n tai maksumuurien kiertämistä.</p>
     `;
 
-    // Add event listeners
-    const closeBtn = panel.querySelector('#anomtube-download-close');
-    closeBtn.addEventListener('click', () => this.hideDownloadUI());
+    this.bindPanelEvents(panel);
+    return panel;
+  }
 
-    const formatBtns = panel.querySelectorAll('.format-btn');
-    formatBtns.forEach(btn => {
-      btn.addEventListener('click', (e) => {
-        this.downloadOptions.format = btn.dataset.format;
-        this.saveSettings();
-        this.updateFormatButtons(formatBtns, btn.dataset.format);
+  bindPanelEvents(panel) {
+    panel.querySelector('#anomtube-download-close')?.addEventListener('click', () => this.hideDownloadUI());
+    panel.querySelector('#anomtube-download-cancel')?.addEventListener('click', () => this.hideDownloadUI());
+
+    panel.querySelectorAll('.anomtube-format-btn').forEach((button) => {
+      button.addEventListener('click', async () => {
+        if (this.isDownloading) return;
+        this.downloadOptions.format = button.dataset.format;
+        await this.saveSettings();
+        this.renderSelectionState();
       });
     });
 
     const qualitySelect = panel.querySelector('#anomtube-quality-select');
-    qualitySelect.addEventListener('change', (e) => {
-      this.downloadOptions.quality = e.target.value;
-      this.saveSettings();
+    qualitySelect?.addEventListener('change', async (event) => {
+      if (this.isDownloading) return;
+      this.downloadOptions.quality = event.target.value;
+      await this.saveSettings();
     });
 
-    const downloadBtn = panel.querySelector('#anomtube-download-btn');
-    downloadBtn.addEventListener('click', () => this.startDownload());
-
-    return panel;
+    panel.querySelector('#anomtube-download-btn')?.addEventListener('click', () => this.startDownload());
   }
 
-  updateFormatButtons(buttons, selectedFormat) {
-    buttons.forEach(btn => {
-      const isSelected = btn.dataset.format === selectedFormat;
-      btn.style.background = isSelected ? 'rgba(108, 168, 255, 0.3)' : 'rgba(255, 255, 255, 0.05)';
-      btn.style.borderColor = isSelected ? 'rgba(108, 168, 255, 0.6)' : 'rgba(255, 255, 255, 0.15)';
+  renderSelectionState() {
+    const panel = document.getElementById('anomtube-download-panel');
+    if (!panel) return;
+
+    panel.querySelectorAll('.anomtube-format-btn').forEach((button) => {
+      const selected = button.dataset.format === this.downloadOptions.format;
+      button.style.cssText = `
+        padding: 14px 12px;
+        border-radius: 14px;
+        border: 1px solid ${selected ? 'rgba(108,168,255,.70)' : 'rgba(255,255,255,.14)'};
+        background: ${selected ? 'linear-gradient(135deg, rgba(108,168,255,.34), rgba(80,243,192,.18))' : 'rgba(255,255,255,.055)'};
+        color: #f8faff;
+        font-weight: 800;
+        letter-spacing: 1.5px;
+        cursor: ${this.isDownloading ? 'not-allowed' : 'pointer'};
+        opacity: ${this.isDownloading ? '.62' : '1'};
+      `;
     });
-  }
 
-  async startDownload() {
-    const statusEl = document.getElementById('anomtube-download-status');
-    const downloadBtn = document.getElementById('anomtube-download-btn');
-    
-    if (!statusEl || !downloadBtn) return;
-
-    // Get current video URL
-    const videoId = new URLSearchParams(window.location.search).get('v');
-    if (!videoId) {
-      this.showStatus('No video detected', 'error');
-      return;
+    const qualitySelect = panel.querySelector('#anomtube-quality-select');
+    if (qualitySelect) {
+      qualitySelect.value = this.downloadOptions.quality;
+      qualitySelect.disabled = this.isDownloading;
     }
+  }
 
-    // Get video title for filename
-    const videoTitle = document.querySelector('h1.title yt-formatted-string')?.textContent || 'video';
-    const sanitizedTitle = videoTitle.replace(/[<>:"/\\|?*]/g, '_').trim();
+  setBusy(isBusy) {
+    this.isDownloading = isBusy;
+    const button = document.getElementById('anomtube-download-btn');
+    if (button) {
+      button.disabled = isBusy;
+      button.textContent = isBusy ? 'Ladataan…' : 'Lataa';
+      button.style.cursor = isBusy ? 'not-allowed' : 'pointer';
+      button.style.opacity = isBusy ? '.62' : '1';
+    }
+    this.renderSelectionState();
+  }
 
-    downloadBtn.disabled = true;
-    downloadBtn.textContent = 'Preparing...';
-    this.showStatus('Preparing download...', 'info');
+  getCurrentVideoPayload() {
+    const canonicalUrl = document.querySelector('link[rel="canonical"]')?.href;
+    const url = canonicalUrl && canonicalUrl.includes('youtube.com/watch') ? canonicalUrl : window.location.href;
+    const titleElement = document.querySelector('h1 yt-formatted-string, h1.title yt-formatted-string, ytd-watch-metadata h1');
+    const rawTitle = titleElement?.textContent?.trim() || document.title || 'anomtube-download';
+    const title = rawTitle.replace(/\s+-\s+YouTube$/i, '').trim() || 'anomtube-download';
+
+    return {
+      url,
+      format: this.downloadOptions.format,
+      quality: this.downloadOptions.quality,
+      title
+    };
+  }
+
+  async startDownload(options = {}) {
+    if (this.isDownloading) return;
+    this.showDownloadUI();
+    this.setBusy(true);
+    this.showStatus('Ladataan — backend käsittelee tiedostoa…', 'loading');
+
+    const payload = { ...this.getCurrentVideoPayload(), ...options };
 
     try {
-      // Since this is a browser extension, we'll use YouTube's direct video URL
-      // Note: This is a simplified version. Real implementation would need backend API
-      const videoUrl = `https://www.youtube.com/watch?v=${videoId}`;
-      
-      // Show information about downloading
-      this.showStatus(
-        `Format: ${this.downloadOptions.format.toUpperCase()} | Quality: ${this.downloadOptions.quality}`,
-        'info'
-      );
+      const response = await fetch(this.backendUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
 
-      // Trigger download using chrome downloads API
-      await this.triggerBrowserDownload(videoUrl, sanitizedTitle);
-      
-      this.showStatus('Download started! Check your downloads folder.', 'success');
+      if (!response.ok) {
+        await this.throwDownloadError(response);
+      }
+
+      const blob = await response.blob();
+      const filename = this.resolveFilename(response, payload.title, payload.format);
+      this.downloadBlob(blob, filename);
+      this.showStatus(`Onnistui — ${filename} käynnistyi selaimen latauksiin.`, 'success');
     } catch (error) {
-      console.error('Download error:', error);
-      this.showStatus('Download failed. Please try again.', 'error');
+      const backendMessage = 'Download backend ei ole käynnissä. Käynnistä: cd backend && npm install && node server.js';
+      const message = error.name === 'TypeError' ? backendMessage : error.message || backendMessage;
+      console.error('AnomTube download failed:', error);
+      this.showStatus(message, 'error');
     } finally {
-      downloadBtn.disabled = false;
-      downloadBtn.textContent = '⬇ Download';
+      this.setBusy(false);
     }
   }
 
-  async triggerBrowserDownload(url, filename) {
-    // Use chrome downloads API to trigger download
-    const ext = this.downloadOptions.format === 'mp3' ? '.mp3' : '.mp4';
-    
-    return new Promise((resolve, reject) => {
-      chrome.runtime.sendMessage({
-        action: 'download',
-        url: url,
-        filename: `${filename}${ext}`,
-        format: this.downloadOptions.format,
-        quality: this.downloadOptions.quality
-      }, (response) => {
-        if (response && response.success) {
-          resolve();
-        } else {
-          reject(new Error(response?.error || 'Download failed'));
-        }
-      });
-    });
+  async throwDownloadError(response) {
+    let errorMessage = `Download failed (${response.status})`;
+    try {
+      const data = await response.json();
+      if (data?.error) errorMessage = data.error;
+    } catch (_error) {
+      const text = await response.text().catch(() => '');
+      if (text) errorMessage = text.slice(0, 240);
+    }
+    throw new Error(errorMessage);
   }
 
-  showStatus(message, type) {
+  resolveFilename(response, title, format) {
+    const disposition = response.headers.get('Content-Disposition') || response.headers.get('content-disposition') || '';
+    const match = disposition.match(/filename="?([^";]+)"?/i);
+    if (match?.[1]) return match[1];
+
+    const safeTitle = (title || 'anomtube-download')
+      .replace(/\s+-\s+YouTube$/i, '')
+      .replace(/[<>:"/\\|?*\u0000-\u001F]/g, '_')
+      .replace(/\s+/g, '_')
+      .slice(0, 140)
+      .replace(/^\.+/, '') || 'anomtube-download';
+
+    return `${safeTitle}.${format === 'mp4' ? 'mp4' : 'mp3'}`;
+  }
+
+  downloadBlob(blob, filename) {
+    const objectUrl = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = objectUrl;
+    anchor.download = filename;
+    anchor.style.display = 'none';
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    setTimeout(() => URL.revokeObjectURL(objectUrl), 2000);
+  }
+
+  showStatus(message, type = 'ready') {
     const statusEl = document.getElementById('anomtube-download-status');
     if (!statusEl) return;
 
-    statusEl.style.display = 'block';
-    statusEl.textContent = message;
-    
     const colors = {
-      info: 'rgba(108, 168, 255, 0.3)',
-      success: 'rgba(80, 243, 192, 0.3)',
-      error: 'rgba(255, 107, 107, 0.3)'
+      ready: ['rgba(255,255,255,.055)', 'rgba(255,255,255,.10)'],
+      loading: ['rgba(108,168,255,.18)', 'rgba(108,168,255,.30)'],
+      success: ['rgba(80,243,192,.18)', 'rgba(80,243,192,.34)'],
+      error: ['rgba(255,107,107,.18)', 'rgba(255,107,107,.34)']
     };
-    
-    statusEl.style.background = colors[type] || colors.info;
-
-    if (type === 'success' || type === 'error') {
-      setTimeout(() => {
-        statusEl.style.display = 'none';
-      }, 5000);
-    }
+    const [background, border] = colors[type] || colors.ready;
+    statusEl.textContent = message;
+    statusEl.style.background = background;
+    statusEl.style.borderColor = border;
   }
 }
 
-// Export for use in content script
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = DownloadManager;
 }

--- a/popup.js
+++ b/popup.js
@@ -1,4 +1,5 @@
 // Popup script for AnomTube extension
+// Engineered for autonomy, designed for humans.
 document.addEventListener('DOMContentLoaded', async () => {
   const toggle = document.getElementById('enableToggle');
   const status = document.getElementById('status');
@@ -18,6 +19,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   const themeToggle = document.getElementById('themeToggle');
   const addBookmarkBtn = document.getElementById('addBookmarkBtn');
   const togglePipBtn = document.getElementById('togglePipBtn');
+  const autoClickSkipAdsToggle = document.getElementById('autoClickSkipAdsToggle');
+  const allowVideoKeepAdSettingsToggle = document.getElementById('allowVideoKeepAdSettingsToggle');
+  const hidePopupCompletelyToggle = document.getElementById('hidePopupCompletelyToggle');
+  const expandToolbarToggle = document.getElementById('expandToolbarToggle');
   const defaultLogoUrl = chrome.runtime.getURL('logo.png');
 
   function updateStatus(enabled) {
@@ -31,6 +36,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   function updatePreview(previewEl, dataUrl, { fallbackUrl = null, emptyLabel = 'Ei kuvaa' } = {}) {
+    if (!previewEl) return;
     const url = dataUrl || fallbackUrl;
     if (url) {
       previewEl.style.backgroundImage = `url("${url}")`;
@@ -56,19 +62,37 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
   }
 
+  function setChecked(element, value) {
+    if (element) element.checked = !!value;
+  }
+
+  function bindChange(element, handler) {
+    if (!element) return;
+    element.addEventListener('change', handler);
+  }
+
+  function bindClick(element, handler) {
+    if (!element) return;
+    element.addEventListener('click', handler);
+  }
+
   async function loadState() {
-    const [{ enabled = false, muteAds = false, skipAds = false, blockAds = false, hideLyrics = false, allowVideo = false, theme = 'dark' }, assets] = await Promise.all([
-      chrome.storage.sync.get(['enabled', 'muteAds', 'skipAds', 'blockAds', 'hideLyrics', 'allowVideo', 'theme']),
+    const [{ enabled = false, muteAds = false, skipAds = false, blockAds = false, hideLyrics = false, allowVideo = false, theme = 'dark', autoClickSkipAds = false, allowVideoKeepAdSettings = false, hidePopupCompletely = false, expandToolbar = true }, assets] = await Promise.all([
+      chrome.storage.sync.get(['enabled', 'muteAds', 'skipAds', 'blockAds', 'hideLyrics', 'allowVideo', 'theme', 'autoClickSkipAds', 'allowVideoKeepAdSettings', 'hidePopupCompletely', 'expandToolbar']),
       chrome.storage.local.get(['customBackground', 'customLogo'])
     ]);
 
-    toggle.checked = !!enabled;
-    muteAdsToggle.checked = !!muteAds;
-    skipAdsToggle.checked = !!skipAds;
-    blockAdsToggle.checked = !!blockAds;
-    hideLyricsToggle.checked = !!hideLyrics;
-    allowVideoToggle.checked = !!allowVideo;
-    themeToggle.checked = theme === 'light';
+    setChecked(toggle, enabled);
+    setChecked(muteAdsToggle, muteAds);
+    setChecked(skipAdsToggle, skipAds);
+    setChecked(blockAdsToggle, blockAds);
+    setChecked(hideLyricsToggle, hideLyrics);
+    setChecked(allowVideoToggle, allowVideo);
+    setChecked(themeToggle, theme === 'light');
+    setChecked(autoClickSkipAdsToggle, autoClickSkipAds);
+    setChecked(allowVideoKeepAdSettingsToggle, allowVideoKeepAdSettings);
+    setChecked(hidePopupCompletelyToggle, hidePopupCompletely);
+    setChecked(expandToolbarToggle, expandToolbar);
     updateStatus(!!enabled);
 
     updatePreview(backgroundPreview, assets.customBackground || null, {
@@ -91,6 +115,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   function bindFileInput(inputEl, storageKey, previewEl, options = {}) {
+    if (!inputEl || !previewEl) return;
     inputEl.addEventListener('change', () => {
       const file = inputEl.files && inputEl.files[0];
       if (!file) {
@@ -109,6 +134,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   function bindSelectButton(buttonEl, inputEl) {
+    if (!buttonEl || !inputEl) return;
     buttonEl.addEventListener('click', (event) => {
       event.preventDefault();
       inputEl.click();
@@ -116,6 +142,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   function bindResetButton(buttonEl, storageKey, previewEl, options = {}) {
+    if (!buttonEl || !previewEl) return;
     buttonEl.addEventListener('click', async (event) => {
       event.preventDefault();
       await storeAsset(storageKey, null);
@@ -127,8 +154,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   await loadState();
 
   // Handle toggle change
-  toggle.addEventListener('change', async (e) => {
-    const enabled = e.target.checked;
+  bindChange(toggle, async (event) => {
+    const enabled = event.target.checked;
 
     await chrome.storage.sync.set({ enabled });
     updateStatus(enabled);
@@ -138,72 +165,41 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
   });
 
-  function buildAdPreferencePayload() {
+  function buildSettingsPayload(extra = {}) {
     return {
-      action: 'updateSettings',
-      settings: {
-        muteAds: !!muteAdsToggle.checked,
-        skipAds: !!skipAdsToggle.checked,
-        blockAds: !!blockAdsToggle.checked,
-        autoClickSkipAds: !!autoClickSkipAdsToggle.checked,
-        allowVideoKeepAdSettings: !!allowVideoKeepAdSettingsToggle.checked,
-        hidePopupCompletely: !!hidePopupCompletelyToggle.checked,
-        expandToolbar: !!expandToolbarToggle.checked
-      }
+      muteAds: !!muteAdsToggle?.checked,
+      skipAds: !!skipAdsToggle?.checked,
+      blockAds: !!blockAdsToggle?.checked,
+      hideLyrics: !!hideLyricsToggle?.checked,
+      allowVideo: !!allowVideoToggle?.checked,
+      autoClickSkipAds: !!autoClickSkipAdsToggle?.checked,
+      allowVideoKeepAdSettings: !!allowVideoKeepAdSettingsToggle?.checked,
+      hidePopupCompletely: !!hidePopupCompletelyToggle?.checked,
+      expandToolbar: expandToolbarToggle ? !!expandToolbarToggle.checked : true,
+      ...extra
     };
-  }
-
-  async function handleSettingChange(key, value) {
-    await chrome.storage.sync.set({ [key]: value });
-    await notifyActiveTab(buildAdPreferencePayload());
   }
 
   async function handleSettingChange(key, value) {
     await chrome.storage.sync.set({ [key]: value });
     await notifyActiveTab({
       action: 'updateSettings',
-      settings: { [key]: value }
+      settings: buildSettingsPayload({ [key]: value })
     });
   }
 
-  muteAdsToggle.addEventListener('change', (event) => {
-    handleSettingChange('muteAds', event.target.checked);
-  });
-
-  skipAdsToggle.addEventListener('change', (event) => {
-    handleSettingChange('skipAds', event.target.checked);
-  });
-
-  blockAdsToggle.addEventListener('change', (event) => {
-    handleSettingChange('blockAds', event.target.checked);
-  });
-
-  autoClickSkipAdsToggle.addEventListener('change', (event) => {
-    handleSettingChange('autoClickSkipAds', event.target.checked);
-  });
-
-  allowVideoKeepAdSettingsToggle.addEventListener('change', (event) => {
-    handleSettingChange('allowVideoKeepAdSettings', event.target.checked);
-  });
-
-  hidePopupCompletelyToggle.addEventListener('change', (event) => {
-    handleSettingChange('hidePopupCompletely', event.target.checked);
-  });
-
-  expandToolbarToggle.addEventListener('change', (event) => {
-    handleSettingChange('expandToolbar', event.target.checked);
-  });
-
-  hideLyricsToggle.addEventListener('change', (event) => {
-    handleSettingChange('hideLyrics', event.target.checked);
-  });
-
-  allowVideoToggle.addEventListener('change', (event) => {
-    handleSettingChange('allowVideo', event.target.checked);
-  });
+  bindChange(muteAdsToggle, (event) => handleSettingChange('muteAds', event.target.checked));
+  bindChange(skipAdsToggle, (event) => handleSettingChange('skipAds', event.target.checked));
+  bindChange(blockAdsToggle, (event) => handleSettingChange('blockAds', event.target.checked));
+  bindChange(autoClickSkipAdsToggle, (event) => handleSettingChange('autoClickSkipAds', event.target.checked));
+  bindChange(allowVideoKeepAdSettingsToggle, (event) => handleSettingChange('allowVideoKeepAdSettings', event.target.checked));
+  bindChange(hidePopupCompletelyToggle, (event) => handleSettingChange('hidePopupCompletely', event.target.checked));
+  bindChange(expandToolbarToggle, (event) => handleSettingChange('expandToolbar', event.target.checked));
+  bindChange(hideLyricsToggle, (event) => handleSettingChange('hideLyrics', event.target.checked));
+  bindChange(allowVideoToggle, (event) => handleSettingChange('allowVideo', event.target.checked));
 
   // Theme toggle handler
-  themeToggle.addEventListener('change', async (event) => {
+  bindChange(themeToggle, async (event) => {
     const theme = event.target.checked ? 'light' : 'dark';
     await chrome.storage.sync.set({ theme });
     await notifyActiveTab({
@@ -213,14 +209,14 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
 
   // Add bookmark button
-  addBookmarkBtn.addEventListener('click', async () => {
+  bindClick(addBookmarkBtn, async () => {
     await notifyActiveTab({
       action: 'addBookmark'
     });
   });
 
   // Toggle PiP button
-  togglePipBtn.addEventListener('click', async () => {
+  bindClick(togglePipBtn, async () => {
     await notifyActiveTab({
       action: 'togglePip'
     });
@@ -267,7 +263,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   if (downloadToggleBtn) {
     downloadToggleBtn.addEventListener('click', async () => {
-      await notifyActiveTab({ action: 'toggleDownload' });
+      await notifyActiveTab({ action: 'openDownloadMenu' });
     });
   }
 
@@ -297,32 +293,32 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (areaName === 'sync') {
       if (Object.prototype.hasOwnProperty.call(changes, 'enabled')) {
         const enabled = !!changes.enabled.newValue;
-        toggle.checked = enabled;
+        setChecked(toggle, enabled);
         updateStatus(enabled);
       }
 
       if (Object.prototype.hasOwnProperty.call(changes, 'muteAds')) {
-        muteAdsToggle.checked = !!changes.muteAds.newValue;
+        setChecked(muteAdsToggle, changes.muteAds.newValue);
       }
 
       if (Object.prototype.hasOwnProperty.call(changes, 'skipAds')) {
-        skipAdsToggle.checked = !!changes.skipAds.newValue;
+        setChecked(skipAdsToggle, changes.skipAds.newValue);
       }
 
       if (Object.prototype.hasOwnProperty.call(changes, 'blockAds')) {
-        blockAdsToggle.checked = !!changes.blockAds.newValue;
+        setChecked(blockAdsToggle, changes.blockAds.newValue);
       }
 
       if (Object.prototype.hasOwnProperty.call(changes, 'hideLyrics')) {
-        hideLyricsToggle.checked = !!changes.hideLyrics.newValue;
+        setChecked(hideLyricsToggle, changes.hideLyrics.newValue);
       }
 
       if (Object.prototype.hasOwnProperty.call(changes, 'allowVideo')) {
-        allowVideoToggle.checked = !!changes.allowVideo.newValue;
+        setChecked(allowVideoToggle, changes.allowVideo.newValue);
       }
 
       if (Object.prototype.hasOwnProperty.call(changes, 'theme')) {
-        themeToggle.checked = changes.theme.newValue === 'light';
+        setChecked(themeToggle, changes.theme.newValue === 'light');
       }
     }
   });


### PR DESCRIPTION
### Motivation
- Provide a safe, user-facing download flow (MP3 / MP4, low/medium/high) integrated into the extension UI and hotkeys without opening blank tabs. 
- Keep existing features intact (audio-only, ad controls, lyrics, PiP, theme, playlists) while delegating heavy lifting to a local backend for conversion. 
- Harden the backend API with strict validation, sanitized filenames and dependency checks so it fails clearly when system tools are missing.

### Description
- UI & content integration: implement a polished download modal in `modules/downloadManager.js` that auto-detects the active YouTube URL/title, prevents concurrent downloads, posts `{url, format, quality, title}` to `http://localhost:3000/api/download`, handles the response as a blob, and triggers a native browser download via `URL.createObjectURL` + `a.download`; wired hotkey (D) and popup button to open the menu via `content.js` and `popup.js`. (files: `modules/downloadManager.js`, `content.js`, `popup.js`).
- Backend: add a small, production-minded Express service with `/api/health` and `POST /api/download`, bounded concurrency queue, runtime checks for `yt-dlp` and `ffmpeg`, structured logging, robust error handling, and no server crashes on job failure; extraction/conversion logic uses `yt-dlp` with `--extract-audio --audio-format mp3` for MP3 and MP4 selectors + `--merge-output-format mp4` for MP4. (files: `backend/server.js`, new `backend/download-core.js`).
- Validation, sanitization & tests: centralize validation and yt-dlp arg building in `backend/download-core.js` (YouTube-only URL validation, format/quality enums, `sanitize-filename` for safe filenames) and add unit tests (`backend/tests/download-core.test.js`) for those core functions.
- Fixes & manifest: remove duplicate `handleSettingChange` and make popup element bindings null-safe; ensure popup `⬇️ Lataa` sends `openDownloadMenu` to the content script; content script accepts `toggleDownload`, `openDownloadMenu`, `startDownload`; update `manifest.json` to include `activeTab`, `storage`, `tabs` and host permissions for YouTube, youtu.be and `http://localhost:3000/*`; update README with run/test instructions. (files: `popup.js`, `manifest.json`, `README.md`).

### Testing
- Static checks: `node --check popup.js`, `node --check content.js`, `node --check modules/downloadManager.js`, `node --check backend/server.js`, `node --check backend/download-core.js` — all passed. 
- Unit tests: `cd backend && npm test` ran `backend/tests/download-core.test.js` (6 tests) and all tests passed. 
- Integration smoke: `curl -i -X POST http://localhost:3000/api/download` with a non-YouTube URL returned `400 Bad Request` as expected. 
- Health check: `curl http://localhost:3000/api/health` returned `503` in this environment with a clear message because `yt-dlp` and `ffmpeg` are not present on PATH (expected; backend fails explicitly and safely). 

All automated checks and unit tests succeeded; full end-to-end MP3/MP4 conversions require system tools `yt-dlp` and `ffmpeg` installed (README includes install steps).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb09d6694083328669354f87521f0d)